### PR TITLE
Adding reconnect()

### DIFF
--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -288,10 +288,12 @@ abstract class AbstractDbEntity implements \Serializable
             }
         }
 
-        $this->dbData[$property] = $value;
-
-        if ($setAsModified && !$this->isDbPropertyModified($property)) {
-            $this->modifiedDbProperties[] = $property;
+        if ($this->dbData[$property] !== $value) {
+            $this->dbData[$property] = $value;
+    
+            if ($setAsModified && !$this->isDbPropertyModified($property)) {
+                $this->modifiedDbProperties[] = $property;
+            }
         }
     }
 

--- a/src/BasicDbEntityService.php
+++ b/src/BasicDbEntityService.php
@@ -34,6 +34,14 @@ class BasicDbEntityService
     {
         $this->db = $db;
     }
+    
+    /**
+     */
+    public function reconnect()
+    {
+        $this->db->disconnect();
+        $this->db->connect();
+    }
 
     /**
      * Load object's values from database table.

--- a/tests/AbstractDbEntityFetcherTest.php
+++ b/tests/AbstractDbEntityFetcherTest.php
@@ -50,7 +50,7 @@ class AbstractDbEntityFetcherTest extends \PHPUnit_Framework_TestCase
 
     public function testGetLimitSqlPageItemInvalidPageNo()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         // Use reflection to make protected method accessible
         $method = new \ReflectionMethod($this->dbFetcher, 'getLimitSql');
@@ -147,7 +147,7 @@ class AbstractDbEntityFetcherTest extends \PHPUnit_Framework_TestCase
     {
         $invalidDbFetcher = new TestIncompleteFetcher($this->mockDb);
 
-        $this->setExpectedException('\LogicException');
+        $this->expectException('\LogicException');
 
         $method = new \ReflectionMethod($invalidDbFetcher, 'getDbEntitiesFromRows');
         $method->setAccessible(true);
@@ -171,7 +171,7 @@ class AbstractDbEntityFetcherTest extends \PHPUnit_Framework_TestCase
     {
         $invalidDbFetcher = new TestIncompleteFetcher($this->mockDb);
 
-        $this->setExpectedException('\LogicException');
+        $this->expectException('\LogicException');
 
         $method = new \ReflectionMethod($invalidDbFetcher, 'getDbEntityFromRow');
         $method->setAccessible(true);

--- a/tests/AbstractDbEntityTest.php
+++ b/tests/AbstractDbEntityTest.php
@@ -12,7 +12,7 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckStaticProperties()
     {
-        $this->setExpectedException('\LogicException');
+        $this->expectException('\LogicException');
 
         new TestIncompleteDbEntity();
     }
@@ -47,7 +47,7 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
 
     public function testSetPrimaryDbValueWithInvalidMultiKey()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $entity = new TestDbEntityMultiPrimary();
         $entity->setPrimaryDbValue(5);
     }
@@ -64,13 +64,13 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
     public function testIsNewDbEntityWithMultiKey()
     {
         $entity = new TestDbEntityMultiPrimary();
-        $this->setExpectedException('\LogicException');
+        $this->expectException('\LogicException');
         $entity->isNewDbEntity();
     }
 
     public function testSetDbValueFail()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
 
         $method = new \ReflectionMethod('\Starlit\Db\AbstractDbEntity', 'SetDbValue');
         $method->setAccessible(true);
@@ -188,14 +188,14 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
     public function test__callFail()
     {
         $entity = new TestDbEntity();
-        $this->setExpectedException('\BadMethodCallException');
+        $this->expectException('\BadMethodCallException');
         $entity->__call('getBlabla');
     }
 
     public function test__callFailArgCount()
     {
         $entity = new TestDbEntity();
-        $this->setExpectedException('\BadMethodCallException');
+        $this->expectException('\BadMethodCallException');
         $entity->__call('setSomeId', [1,2,3]);
     }
 
@@ -329,7 +329,7 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateAndSetDbDataFail()
     {
-        $mockTranslator = $this->getMock('\Starlit\Utils\Validation\ValidatorTranslatorInterface');
+        $mockTranslator = $this->getMockBuilder('\Starlit\Utils\Validation\ValidatorTranslatorInterface')->getMock();
 
         $mockTranslator->expects($this->atLeastOnce())
             ->method('trans')

--- a/tests/BasicDbEntityServiceTest.php
+++ b/tests/BasicDbEntityServiceTest.php
@@ -25,7 +25,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testLoadThrowsExceptionWithInvalidEntity()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $entity = new ServiceTestEntity();
         $this->dbService->load($entity);
     }
@@ -36,7 +36,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
             ->method('fetchRow')
             ->will($this->returnValue(false));
 
-        $this->setExpectedException('\RuntimeException');
+        $this->expectException('\RuntimeException');
         $entity = new ServiceTestEntity(1);
         $this->dbService->load($entity);
     }
@@ -113,7 +113,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
         $entity = new ServiceTestEntity();
         $entity->setSomeName('12345678901');
 
-        $this->setExpectedException('\RuntimeException');
+        $this->expectException('\RuntimeException');
         $this->dbService->save($entity);
     }
 
@@ -122,7 +122,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
         $entity = new ServiceTestEntity();
         $entity->setSomeName('');
 
-        $this->setExpectedException('\RuntimeException');
+        $this->expectException('\RuntimeException');
         $this->dbService->save($entity);
     }
 
@@ -132,7 +132,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
         $entity->setSomeName('A Name');
         $entity->setSomeValue(0);
 
-        $this->setExpectedException('\RuntimeException');
+        $this->expectException('\RuntimeException');
         $this->dbService->save($entity);
     }
 
@@ -174,7 +174,7 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
     {
         $entity = new ServiceTestEntity();
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $this->dbService->delete($entity);
     }
 

--- a/tests/BasicDbEntityServiceTest.php
+++ b/tests/BasicDbEntityServiceTest.php
@@ -177,6 +177,15 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\InvalidArgumentException');
         $this->dbService->delete($entity);
     }
+
+    public function testReconnect()
+    {
+        $mockDb = $this->getMockBuilder('Starlit\Db\Db')->disableOriginalConstructor()->getMock();
+        $mockDb->expects($this->once())->method('disconnect');
+        $mockDb->expects($this->once())->method('connect');
+        $entity = new BasicDbEntityService($mockDb);
+        $entity->reconnect();
+    }
 }
 
 class ServiceTestEntity extends AbstractDbEntity

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -43,7 +43,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [1, false];
         $rowCount = 5;
 
-        $mockPdoStatement = $this->getMock('\PDOStatement');
+        $mockPdoStatement = $this->getMockBuilder('\PDOStatement')->getMock();
 
         $this->mockPdo->expects($this->once())
             ->method('prepare')
@@ -68,7 +68,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
             ->method('prepare')
             ->willThrowException(new \PDOException());
 
-        $this->setExpectedException('\Starlit\Db\Exception\QueryException');
+        $this->expectException('\Starlit\Db\Exception\QueryException');
         $this->db->exec('NO SQL');
     }
 
@@ -78,7 +78,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [1];
         $tableData = ['id' => 5];
 
-        $mockPdoStatement = $this->getMock('\PDOStatement');
+        $mockPdoStatement = $this->getMockBuilder('\PDOStatement')->getMock();
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -101,7 +101,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [3];
         $tableData = [['id' => 1], ['id' => 2]];
 
-        $mockPdoStatement = $this->getMock('\PDOStatement');
+        $mockPdoStatement = $this->getMockBuilder('\PDOStatement')->getMock();
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -124,7 +124,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [10];
         $result = 5;
 
-        $mockPdoStatement = $this->getMock('\PDOStatement');
+        $mockPdoStatement = $this->getMockBuilder('\PDOStatement')->getMock();
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -215,7 +215,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $expectedSql = "INSERT INTO `" . $table . "` (`id`, `name`)\nVALUES (?, ?)";
         $expectedAffectedRows = 1;
 
-        $mockDb = $this->getMock('\Starlit\Db\Db', ['exec'], [], '', false);
+        $mockDb = $this->getMockBuilder('\Starlit\Db\Db')
+            ->setMethods(['exec'])->setConstructorArgs([])->disableOriginalConstructor()->getMock();
         $mockDb->expects($this->once())
             ->method('exec')
             ->with($expectedSql, array_values($insertData))
@@ -235,7 +236,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $expectedSql = "UPDATE `" . $table . "`\nSET `name` = ?\nWHERE `name` = ?";
         $expectedAffectedRows = 1;
 
-        $mockDb = $this->getMock('\Starlit\Db\Db', ['exec'], [], '', false);
+        $mockDb = $this->getMockBuilder('\Starlit\Db\Db')
+            ->setMethods(['exec'])->setConstructorArgs([])->disableOriginalConstructor()->getMock();
         $mockDb->expects($this->once())
             ->method('exec')
             ->with($expectedSql, array_merge(array_values($updateData), $whereParameters))

--- a/tests/Exception/QueryExceptionTest.php
+++ b/tests/Exception/QueryExceptionTest.php
@@ -14,7 +14,7 @@ class QueryExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $mockPdoException = $this->getMock('\PDOException');
+        $mockPdoException = $this->getMockBuilder('\PDOException')->getMock();
 
         $this->exception = new QueryException($mockPdoException, $this->sql, $this->parameters);
     }

--- a/tests/Migration/AbstractMigrationTest.php
+++ b/tests/Migration/AbstractMigrationTest.php
@@ -29,7 +29,7 @@ class AbstractMigrationTest extends \PHPUnit_Framework_TestCase
     {
         $migration = new TestInvalidMigration($this->mockDb);
 
-        $this->setExpectedException('\LogicException');
+        $this->expectException('\LogicException');
         $migration->getNumber();
     }
 

--- a/tests/Migration/MigratorTest.php
+++ b/tests/Migration/MigratorTest.php
@@ -124,7 +124,7 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
         ];
         $this->mockDb->expects($this->any())->method('fetchAll')->willReturn($migrationTableRows);
 
-        $this->setExpectedException('\RuntimeException');
+        $this->expectException('\RuntimeException');
         $this->migrator->migrate();
     }
 
@@ -136,7 +136,7 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
         ];
         $this->mockDb->expects($this->any())->method('fetchAll')->willReturn($migrationTableRows);
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $this->migrator->migrate('bla');
     }
 
@@ -148,7 +148,7 @@ class MigratorTest extends \PHPUnit_Framework_TestCase
         ];
         $this->mockDb->expects($this->any())->method('fetchAll')->willReturn($migrationTableRows);
 
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->expectException('\InvalidArgumentException');
         $this->migrator->migrate(3);
     }
 }


### PR DESCRIPTION
Add `reconnect()` to BasicDbEntityService; Replacing PHPUnits deprecated methods with the new ones
