### PR TITLE
Add `reconnect()` to BasicDbEntityService

### DIFF
--- a/src/BasicDbEntityService.php
+++ b/src/BasicDbEntityService.php
@@ -34,6 +34,14 @@ class BasicDbEntityService
     {
         $this->db = $db;
     }
+    
+    /**
+     */
+    public function reconnect()
+    {
+        $this->db->disconnect();
+        $this->db->connect();
+    }
 
     /**
      * Load object's values from database table.

--- a/tests/BasicDbEntityServiceTest.php
+++ b/tests/BasicDbEntityServiceTest.php
@@ -177,6 +177,15 @@ class BasicDbEntityServiceTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('\InvalidArgumentException');
         $this->dbService->delete($entity);
     }
+
+    public function testReconnect()
+    {
+        $mockDb = $this->getMockBuilder('Starlit\Db\Db')->disableOriginalConstructor()->getMock();
+        $mockDb->expects($this->once())->method('disconnect');
+        $mockDb->expects($this->once())->method('connect');
+        $entity = new BasicDbEntityService($mockDb);
+        $entity->reconnect();
+    }
 }
 
 class ServiceTestEntity extends AbstractDbEntity


### PR DESCRIPTION
Adding a reconnect function the BasicDbEntityService
