### PR TITLE
Allow getting modified db properties

### DIFF
--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -486,6 +486,14 @@ abstract class AbstractDbEntity implements \Serializable
     }
 
     /**
+     * @return array
+     */
+    public function getModifiedDbProperties()
+    {
+        return $this->modifiedDbProperties;
+    }
+
+    /**
      * @param string $property
      */
     public function clearModifiedDbProperty($property)


### PR DESCRIPTION
While getting the `modifiedDbData` is convenient, there are times when simply getting the `modifiedDbProperties` is enough and this would give a minor optimization in those cases.