### PR TITLE
fixes check inside DB::executeQuery method if excute function of pdo statement fails

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -189,7 +189,11 @@ class Db
         $dbParameters = $this->prepareParameters($parameters);
         try {
             $pdoStatement = $this->pdo->prepare($sql);
-            $pdoStatement->execute($dbParameters);
+            if(!$pdoStatement->execute($dbParameters)) {
+                $message = $pdoStatement->errorInfo()[2];
+
+                throw new PDOException($message);
+            }
 
             return $pdoStatement;
         } catch (PDOException $e) {

--- a/src/Db.php
+++ b/src/Db.php
@@ -190,9 +190,9 @@ class Db
         try {
             $pdoStatement = $this->pdo->prepare($sql);
             if(!$pdoStatement->execute($dbParameters)) {
-                $message = $pdoStatement->errorInfo()[2];
+                $errorInfo = $pdoStatement->errorInfo();
 
-                throw new PDOException($message);
+                throw new PDOException($errorInfo[2], $errorInfo[1]);
             }
 
             return $pdoStatement;


### PR DESCRIPTION
The function `Db::executeQuery` can fail silently as the return type of    [`$pdoStatement->execute($dbParameters)`](https://secure.php.net/manual/en/pdostatement.execute.php) is not checked.

This PR tries to solve this by throwing a `PDOException` when the execute call fails.

