### PR TITLE
fix loose type comparison in AbstractDbEntity::clearModifiedDbProperty

### DIFF
--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -498,7 +498,7 @@ abstract class AbstractDbEntity implements \Serializable
      */
     public function clearModifiedDbProperty($property)
     {
-        if (($key = array_search($property, $this->modifiedDbProperties))) {
+        if (($key = array_search($property, $this->modifiedDbProperties)) !== false) {
             unset($this->modifiedDbProperties[$key]);
         }
     }

--- a/tests/AbstractDbEntityTest.php
+++ b/tests/AbstractDbEntityTest.php
@@ -196,6 +196,15 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($entity->hasModifiedDbProperties());
     }
 
+    public function testClearModifiedDbProperty()
+    {
+        $entity = new TestDbEntity();
+        $entity->setSomeField(true);
+        $this->assertSame(['someField'], $entity->getModifiedDbProperties());
+        $entity->clearModifiedDbProperty('someField');
+        $this->assertFalse($entity->hasModifiedDbProperties());
+    }
+
     public function testGetDbPropertyName()
     {
         $this->assertEquals('someName', TestDbEntity::getDbPropertyName('some_name'));


### PR DESCRIPTION
The loose comparison check here is a bug as it will fail for the first element with an index of `0`:

https://github.com/starweb/starlit-db/blob/master/src/AbstractDbEntity.php#L501

This PR changes the check to a strict comparison.