### PR TITLE
Cleanup construction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=7.0",
+        "ext-pdo": "*",
         "ext-pdo_mysql": "*",
         "starlit/utils": "~0.1"
     },

--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -344,7 +344,8 @@ abstract class AbstractDbEntity implements \Serializable
      * @param mixed  $value
      * @return mixed
      */
-    private function getValueWithPropertyType(string $property, $value) {
+    private function getValueWithPropertyType(string $property, $value)
+    {
         if (!isset(static::$dbProperties[$property])) {
             throw new \InvalidArgumentException("No database entity property[{$property}] exists");
         }
@@ -374,7 +375,8 @@ abstract class AbstractDbEntity implements \Serializable
      * @param mixed $value
      * @return mixed
      */
-    private function getPrimaryDbValueWithPropertyType($primaryDbValue) {
+    private function getPrimaryDbValueWithPropertyType($primaryDbValue)
+    {
         if (is_array(static::$primaryDbPropertyKey)) {
             if (!is_array($primaryDbValue)
                 || count(static::$primaryDbPropertyKey) !== count($primaryDbValue)

--- a/src/BasicDbEntityService.php
+++ b/src/BasicDbEntityService.php
@@ -148,7 +148,6 @@ class BasicDbEntityService
                 $sqlData,
                 $this->getPrimaryKeyWhereSql($dbEntity),
                 $this->getPrimaryKeyWhereParameters($dbEntity)
-
             );
         }
 

--- a/src/Db.php
+++ b/src/Db.php
@@ -104,15 +104,13 @@ class Db
         $this->pdoFactory = $pdoFactory ?? new PdoFactory();
     }
 
-    /**
-     */
     public function connect()
     {
         if ($this->isConnected()) {
             return;
         }
 
-        $retries = isset($this->options['connectRetries']) ? $this->options['connectRetries'] : 0;
+        $retries = $this->options['connectRetries'] ?? 0;
         do {
             try {
                 $this->pdo = $this->pdoFactory->createPdo($this->dsn, $this->username, $this->password, $this->options);

--- a/src/Db.php
+++ b/src/Db.php
@@ -54,32 +54,54 @@ class Db
     protected $hasActiveTransaction = false;
 
     /**
+     * @var PdoFactoryInterface
+     */
+    private $pdoFactory;
+
+    /**
      * Constructor.
      *
-     * @param string|PDO  $hostDsnOrPdo A MySQL host, a dsn or an existing PDO instance.
-     * @param string|null $username
-     * @param string|null $password
-     * @param string|null $database
-     * @param array       $options
+     * @param string|PDO            $hostDsnOrPdo A MySQL host, a dsn or an existing PDO instance.
+     * @param string|null           $username
+     * @param string|null           $password
+     * @param string|null           $database
+     * @param array                 $options
+     * @param PdoFactoryInterface   $pdoFactory
+     *
+     * @deprecated  The signature of the constructor will change in version 1.0.0 and accept
+     *              only a PDO dsn string as first parameter dropping support to inject a PDO instance or host string
      */
     public function __construct(
         $hostDsnOrPdo,
         $username = null,
         $password = null,
         $database = null,
-        array $options = []
+        array $options = [],
+        PdoFactoryInterface $pdoFactory = null
     ) {
         if ($hostDsnOrPdo instanceof PDO) {
+            @trigger_error(
+                'support to pass a PDO instance to the constructor is deprecated and will be removed in version 1.0.0.'
+                . ' You need to pass in a PDO dsn in the future as first parameter.',
+                E_USER_DEPRECATED
+            );
+
             $this->pdo = $hostDsnOrPdo;
         } elseif (strpos($hostDsnOrPdo, ':') !== false) {
             $this->dsn = $hostDsnOrPdo;
         } else {
+            @trigger_error(
+                'support to pass a host and database to the constructor is deprecated and will be removed in version '
+                . '1.0.0. You need to pass in a PDO dsn in the future as first parameter.',
+                E_USER_DEPRECATED
+            );
             $this->dsn = "mysql:host={$hostDsnOrPdo}" . ($database ? ";dbname={$database}" : '');
         }
 
         $this->username = $username;
         $this->password = $password;
         $this->options = $options;
+        $this->pdoFactory = $pdoFactory ?? new PdoFactory();
     }
 
     /**
@@ -90,25 +112,10 @@ class Db
             return;
         }
 
-        $retries = isset($this->options['connectRetries'])? $this->options['connectRetries'] : 0;
+        $retries = isset($this->options['connectRetries']) ? $this->options['connectRetries'] : 0;
         do {
             try {
-                $defaultPdoOptions = [
-                    PDO::ATTR_TIMEOUT            => 5,
-                    // We want emulation by default (faster for single queries). Disable if you want to
-                    // use proper native prepared statements
-                    PDO::ATTR_EMULATE_PREPARES   => true,
-                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                ];
-                $pdoOptions = $defaultPdoOptions + (isset($this->options['pdo']) ? $this->options['pdo'] : []);
-
-                $this->pdo = new PDO(
-                    $this->dsn,
-                    $this->username,
-                    $this->password,
-                    $pdoOptions
-                );
+                $this->pdo = $this->pdoFactory->createPdo($this->dsn, $this->username, $this->password, $this->options);
 
                 return;
             } catch (PDOException $e) {

--- a/src/Db.php
+++ b/src/Db.php
@@ -124,7 +124,6 @@ class Db
                     throw new ConnectionException($e);
                 }
             }
-
         } while ($retries-- > 0);
     }
 

--- a/src/Db.php
+++ b/src/Db.php
@@ -81,7 +81,7 @@ class Db
     ) {
         if ($hostDsnOrPdo instanceof PDO) {
             @trigger_error(
-                'support to pass a PDO instance to the constructor is deprecated and will be removed in version 1.0.0.'
+                'Support to pass a PDO instance to the constructor is deprecated and will be removed in version 1.0.0.'
                 . ' You need to pass in a PDO dsn in the future as first parameter.',
                 E_USER_DEPRECATED
             );
@@ -91,7 +91,7 @@ class Db
             $this->dsn = $hostDsnOrPdo;
         } else {
             @trigger_error(
-                'support to pass a host and database to the constructor is deprecated and will be removed in version '
+                'Support to pass a host and database to the constructor is deprecated and will be removed in version '
                 . '1.0.0. You need to pass in a PDO dsn in the future as first parameter.',
                 E_USER_DEPRECATED
             );

--- a/src/Migration/Migrator.php
+++ b/src/Migration/Migrator.php
@@ -134,7 +134,6 @@ class Migrator
         $latest = end($numbers);
 
         return ($latest !== false) ? $latest : 0;
-
     }
 
     /**
@@ -371,12 +370,10 @@ class Migrator
                 $this->addInfo(sprintf(' - Migrating up %d...', $migration->getNumber()));
                 $migration->up();
                 $this->addMigratedMigration($migration);
-
             } else {
                 $this->addInfo(sprintf(' - Migrating down %d...', $migration->getNumber()));
                 $migration->down();
                 $this->deleteMigratedMigration($migration);
-
             }
         }
     }

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -14,6 +14,17 @@ class PdoFactory implements PdoFactoryInterface
 {
     public function createPdo(string $dsn, string $username = null, string $password = null, array $options = []): PDO
     {
-        return new PDO($dsn, $username, $password, $options);
+        $defaultPdoOptions = [
+            PDO::ATTR_TIMEOUT => 5,
+            // We want emulation by default (faster for single queries). Disable if you want to
+            // use proper native prepared statements
+            PDO::ATTR_EMULATE_PREPARES => true,
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        ];
+
+        $pdoOptions = $defaultPdoOptions + $options;
+
+        return new PDO($dsn, $username, $password, $pdoOptions);
     }
 }

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Starlit Db.
+ *
+ * @copyright Copyright (c) 2016 Starweb AB
+ * @license   BSD 3-Clause
+ */
+
+namespace Starlit\Db;
+
+use PDO;
+
+class PdoFactory implements PdoFactoryInterface
+{
+    public function createPdo(string $dsn, string $username = null, string $password = null, array $options = []): PDO
+    {
+        return new PDO($dsn, $username, $password, $options);
+    }
+}

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -2,7 +2,7 @@
 /**
  * Starlit Db.
  *
- * @copyright Copyright (c) 2016 Starweb AB
+ * @copyright Copyright (c) 2019 Starweb AB
  * @license   BSD 3-Clause
  */
 

--- a/src/PdoFactoryInterface.php
+++ b/src/PdoFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Starlit Db.
+ *
+ * @copyright Copyright (c) 2016 Starweb AB
+ * @license   BSD 3-Clause
+ */
+
+namespace Starlit\Db;
+
+use PDO;
+
+interface PdoFactoryInterface
+{
+    public function createPdo(string $dsn, string $username = null, string $password = null, array $options = []): PDO;
+}

--- a/src/PdoFactoryInterface.php
+++ b/src/PdoFactoryInterface.php
@@ -2,7 +2,7 @@
 /**
  * Starlit Db.
  *
- * @copyright Copyright (c) 2016 Starweb AB
+ * @copyright Copyright (c) 2019 Starweb AB
  * @license   BSD 3-Clause
  */
 

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -2,6 +2,11 @@
 
 namespace Starlit\Db;
 
+use DateTime;
+use PDO;
+use PDOException;
+use PDOStatement;
+
 class DbTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -16,7 +21,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->mockPdo = $this->createMock(\PDO::class);
+        $this->mockPdo = $this->createMock(PDO::class);
         $this->db = new Db($this->mockPdo);
     }
 
@@ -42,7 +47,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPdoIsPdoInstance()
     {
-        $this->assertInstanceOf('\PDO', $this->db->getPdo());
+        $this->assertInstanceOf(PDO::class, $this->db->getPdo());
     }
 
     public function testExecCallsPdoWithSqlAndParams()
@@ -51,7 +56,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [1, 2.3, true, false, 'abc', null];
         $rowCount = 5;
 
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
 
         $this->mockPdo->expects($this->once())
             ->method('prepare')
@@ -72,11 +77,11 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     public function testDateTimeParameterIsConvertedToString()
     {
-        $dateTime = new \DateTime('2000-01-01 00:00:00');
+        $dateTime = new DateTime('2000-01-01 00:00:00');
         $sqlParameters = [$dateTime];
         $sql = '';
 
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
 
         $this->mockPdo
             ->method('prepare')
@@ -94,7 +99,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
     {
         $this->mockPdo
             ->method('prepare')
-            ->willThrowException(new \PDOException());
+            ->willThrowException(new PDOException());
 
         $this->expectException(\Starlit\Db\Exception\QueryException::class);
         $this->db->exec('NO SQL');
@@ -102,7 +107,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
     public function testExecThrowsExceptionWithInvalidParameterTypes()
     {
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
         $this->mockPdo->method('prepare')->willReturn($mockPdoStatement);
 
         $this->expectException(\InvalidArgumentException::class);
@@ -117,7 +122,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [1];
         $tableData = ['id' => 5];
 
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -140,7 +145,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [3];
         $tableData = [['id' => 1], ['id' => 2]];
 
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -163,7 +168,7 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $sqlParameters = [10];
         $result = 5;
 
-        $mockPdoStatement = $this->createMock(\PDOStatement::class);
+        $mockPdoStatement = $this->createMock(PDOStatement::class);
         $this->mockPdo->expects($this->once())
             ->method('prepare')
             ->with($sql)
@@ -315,6 +320,5 @@ class DbTest extends \PHPUnit_Framework_TestCase
             $expectedAffectedRows,
             $mockDb->update($table, $updateData, $whereSql, $whereParameters)
         );
-
     }
 }

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -36,7 +36,8 @@ class DbTest extends \PHPUnit_Framework_TestCase
     {
         $expectedErrorStack = [
             [
-                'message'   => 'Support to pass a PDO instance to the constructor is deprecated and will be removed in version 1.0.0.'
+                'message'   => 'Support to pass a PDO instance to the constructor is deprecated and '
+                                . 'will be removed in version 1.0.0.'
                                 . ' You need to pass in a PDO dsn in the future as first parameter.',
                 'type'      => E_USER_DEPRECATED
             ]
@@ -53,8 +54,9 @@ class DbTest extends \PHPUnit_Framework_TestCase
 
         $expectedErrorStack = [
             [
-                'message'   => 'Support to pass a host and database to the constructor is deprecated and will be removed in version '
-                                . '1.0.0. You need to pass in a PDO dsn in the future as first parameter.',
+                'message'   => 'Support to pass a host and database to the constructor is deprecated and will be '
+                                . 'removed in version 1.0.0. '
+                                . 'You need to pass in a PDO dsn in the future as first parameter.',
                 'type'      => E_USER_DEPRECATED
             ]
         ];

--- a/tests/Helper/ErrorFunctions.php
+++ b/tests/Helper/ErrorFunctions.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Starlit\Db {
+    class ErrorStackTestHelper
+    {
+        public static $errors = [];
+    }
+
+    function trigger_error(string $error_msg, $type = E_USER_NOTICE)
+    {
+        ErrorStackTestHelper::$errors[] = [
+            'message' => $error_msg,
+            'type' => $type
+        ];
+    }
+
+    function usleed(int $start, int $stop)
+    {
+
+    }
+}

--- a/tests/Helper/ErrorFunctions.php
+++ b/tests/Helper/ErrorFunctions.php
@@ -13,9 +13,4 @@ namespace Starlit\Db {
             'type' => $type
         ];
     }
-
-    function usleed(int $start, int $stop)
-    {
-
-    }
 }

--- a/tests/Helper/ErrorFunctions.php
+++ b/tests/Helper/ErrorFunctions.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 namespace Starlit\Db {
+
     class ErrorStackTestHelper
     {
         public static $errors = [];

--- a/tests/PdoFactoryTest.php
+++ b/tests/PdoFactoryTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Starlit\Db;
 

--- a/tests/PdoFactoryTest.php
+++ b/tests/PdoFactoryTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Starlit\Db;
+
+use PDO;
+
+class PdoFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PdoFactoryInterface
+     */
+    private $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new PdoFactory();
+    }
+
+    public function testConstruction()
+    {
+        $this->assertInstanceOf(PdoFactoryInterface::class, $this->factory);
+    }
+
+    public function testCreatePdo()
+    {
+        $pdo = $this->factory->createPdo('sqlite::memory');
+        $this->assertInstanceOf(PDO::class, $pdo);
+    }
+}


### PR DESCRIPTION
This PR prepares the construction cleanup by triggering deprecation erros when using the constructor with a `PDO` object or a host and database string.

Adds a `PdoFactoryInterface` as constructor argument which creates a new `PDO` instance inside of the `Db::connect` function.