### PR TITLE
Make sure we don't break backward compatibility

### DIFF
--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -23,7 +23,7 @@ class PdoFactory implements PdoFactoryInterface
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ];
 
-        $pdoOptions = $defaultPdoOptions + (isset($options['pdo']) ? $options['pdo'] : []);
+        $pdoOptions = array_merge($defaultPdoOptions, (isset($options['pdo']) ? $options['pdo'] : []));
 
         return new PDO($dsn, $username, $password, $pdoOptions);
     }

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -23,7 +23,7 @@ class PdoFactory implements PdoFactoryInterface
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ];
 
-        $pdoOptions = \array_merge($defaultPdoOptions, (isset($options['pdo']) ? $options['pdo'] : []));
+        $pdoOptions = $defaultPdoOptions + (isset($options['pdo']) ? $options['pdo'] : []);
 
         return new PDO($dsn, $username, $password, $pdoOptions);
     }

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -23,7 +23,7 @@ class PdoFactory implements PdoFactoryInterface
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ];
 
-        $pdoOptions = $defaultPdoOptions + $options;
+        $pdoOptions = $defaultPdoOptions + (isset($options['pdo']) ? $options['pdo'] : []);
 
         return new PDO($dsn, $username, $password, $pdoOptions);
     }

--- a/src/PdoFactory.php
+++ b/src/PdoFactory.php
@@ -23,7 +23,7 @@ class PdoFactory implements PdoFactoryInterface
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
         ];
 
-        $pdoOptions = array_merge($defaultPdoOptions, (isset($options['pdo']) ? $options['pdo'] : []));
+        $pdoOptions = \array_merge($defaultPdoOptions, (isset($options['pdo']) ? $options['pdo'] : []));
 
         return new PDO($dsn, $username, $password, $pdoOptions);
     }


### PR DESCRIPTION
## Bug: PDO options could no longer be sent into the PDO class

### Cause of bug
Previous versions of Starlit/Db allowed PDO options to be send in using an options array with the following format: `$option = ['pdo' => [...]]`

The latest versions of Starlit/Db breaks this by instead requiring the array to be in the format `$options = [...]`, thus breaking backward compatibility and also removing the ability to send in non PDO options to the Starlit/Db class

### Solution
Revert to use the previous options format for the array. This allows us to also add non PDO options for the Starlit/Db at a later stage if we wish