### PR TITLE
Handle added DB columns on unserialize

### DIFF
--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -878,6 +878,10 @@ abstract class AbstractDbEntity implements \Serializable
         foreach ($objectVars as $key => $value) {
             $this->{$key} = $value;
         }
+
+        foreach (array_diff_key(static::$dbProperties, $this->dbData) as $missingProperty => $value) {
+            $this->dbData[$missingProperty] = $this->getDefaultDbPropertyValue($missingProperty);
+        }
     }
 
     /**

--- a/tests/AbstractDbEntityTest.php
+++ b/tests/AbstractDbEntityTest.php
@@ -494,6 +494,25 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(123, $unserializedEntity->publicProperty);
     }
 
+    public function testUnserializeWithMissingProperties()
+    {
+        $entity = new TestDbEntity();
+
+        $reflectionClass = (new \ReflectionClass($entity))->getParentClass();
+        $reflectionProperty = $reflectionClass->getProperty('dbData');
+        $reflectionProperty->setAccessible(true);
+        $dbData = $reflectionProperty->getValue($entity);
+        unset($dbData['someName']);
+        $reflectionProperty->setValue($entity, $dbData);
+
+        $unserializedEntity = unserialize(serialize($entity));
+
+        $this->assertEquals(
+            $entity->getDefaultDbPropertyValue('someName'),
+            $unserializedEntity->getDbData()['someName']
+        );
+    }
+
     public function testMergeWith()
     {
         $entity = new TestDbEntity();


### PR DESCRIPTION
## Improvement: Account for Added DB Properties When Aeserializing AbstractDbEntity Objects

### Cause For Change
Unserialized AbstractDbEntity objects, e.g. from sessions throw ErrorExceptions when trying to set database properties that didn't exist before serialization.

### Solution
Check for missing keys in dbData un unserialization and add them with default values.