### PR TITLE
Declare utf8mb4 charset on every MySQL connection.

### DIFF
--- a/src/Db.php
+++ b/src/Db.php
@@ -88,20 +88,41 @@ class Db
 
             $this->pdo = $hostDsnOrPdo;
         } elseif (strpos($hostDsnOrPdo, ':') !== false) {
-            $this->dsn = $hostDsnOrPdo;
+            $this->dsn = $this->ensureUtf8mb4Charset($hostDsnOrPdo);
         } else {
             @trigger_error(
                 'Support to pass a host and database to the constructor is deprecated and will be removed in version '
                 . '1.0.0. You need to pass in a PDO dsn in the future as first parameter.',
                 E_USER_DEPRECATED
             );
-            $this->dsn = "mysql:host={$hostDsnOrPdo}" . ($database ? ";dbname={$database}" : '');
+            $this->dsn = $this->ensureUtf8mb4Charset(
+                "mysql:host={$hostDsnOrPdo}" . ($database ? ";dbname={$database}" : '')
+            );
         }
 
         $this->username = $username;
         $this->password = $password;
         $this->options = $options;
         $this->pdoFactory = $pdoFactory ?? new PdoFactory();
+    }
+
+    /**
+     * Ensure a MySQL DSN declares utf8mb4 as the connection charset.
+     *
+     * The charset must be negotiated per connection rather than relying on the server default
+     * (e.g. skip-character-set-client-handshake), which no longer exists on MySQL 8.4. Setting it
+     * via the DSN also updates the driver's internal charset used for client-side escaping.
+     *
+     * Only mysql DSNs are touched, an explicitly supplied charset is preserved, and the operation
+     * is idempotent.
+     */
+    private function ensureUtf8mb4Charset(string $dsn): string
+    {
+        if (strncmp($dsn, 'mysql:', 6) === 0 && stripos($dsn, 'charset=') === false) {
+            return $dsn . ';charset=utf8mb4';
+        }
+
+        return $dsn;
     }
 
     public function connect()

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -79,6 +79,42 @@ class DbTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(PDO::class, $db->getPdo());
     }
 
+    public function testFullMysqlDsnWithoutCharsetGetsUtf8mb4Appended()
+    {
+        $this->mockPdoFactory
+            ->expects($this->once())
+            ->method('createPdo')
+            ->with('mysql:host=localhost;dbname=database;charset=utf8mb4', null, null, [])
+            ->willReturn($this->mockPdo);
+
+        $db = new Db('mysql:host=localhost;dbname=database', null, null, null, [], $this->mockPdoFactory);
+        $db->connect();
+    }
+
+    public function testExplicitCharsetInDsnIsPreserved()
+    {
+        $this->mockPdoFactory
+            ->expects($this->once())
+            ->method('createPdo')
+            ->with('mysql:host=localhost;charset=latin1', null, null, [])
+            ->willReturn($this->mockPdo);
+
+        $db = new Db('mysql:host=localhost;charset=latin1', null, null, null, [], $this->mockPdoFactory);
+        $db->connect();
+    }
+
+    public function testNonMysqlDsnIsNotModified()
+    {
+        $this->mockPdoFactory
+            ->expects($this->once())
+            ->method('createPdo')
+            ->with('sqlite::memory', null, null, [])
+            ->willReturn($this->mockPdo);
+
+        $db = new Db('sqlite::memory', null, null, null, [], $this->mockPdoFactory);
+        $db->connect();
+    }
+
     public function testRetryConnectOnPdoCreationFailureThrowsConnectionException()
     {
         $this->mockPdoFactory


### PR DESCRIPTION
### Testing
- **`DbCharsetTest`** (new) — asserts the DSN handed to `PdoFactory::createPdo`:
  - host-string construction → `;charset=utf8mb4` appended
  - full mysql DSN without charset → appended
  - DSN already carrying a charset → unchanged (no duplication)
  - non-mysql (sqlite) DSN → untouched
- **`DbReadReplicaSupportTraitTest`** — DSN assertions updated to expect the appended charset on primary **and** read-replica connections.
- Integration clone-command tests build DSNs manually and don't assert on the string — unaffected.

> Companion PR in `starweb`repo