### PR TITLE
fix: Return array from AbstractDbEntity::__serialize() per PHP magic-…

### DIFF
--- a/src/AbstractDbEntity.php
+++ b/src/AbstractDbEntity.php
@@ -851,31 +851,29 @@ abstract class AbstractDbEntity
     }
 
     /**
-     * Method to handle the serialization of this object.
+     * Handle the serialization of this object (PHP __serialize() contract).
      *
-     * Implementation of Serializable interface. If descendant private properties
-     * should be serialized, they need to be visible to this parent (i.e. not private).
+     * Must return an array. If descendant private properties should be serialized, they need to
+     * be visible to this parent (i.e. not private).
      *
-     * @return string
+     * @return array
      */
-    public function __serialize()
+    public function __serialize(): array
     {
-        return serialize(get_object_vars($this));
+        return get_object_vars($this);
     }
 
     /**
-     * Method to handle the unserialization of this object.
+     * Handle the unserialization of this object (PHP __unserialize() contract).
      *
-     * Implementation of Serializable interface. If descendant private properties
-     * should be unserialized, they need to be visible to this parent (i.e. not private).
+     * Receives the array produced by __serialize() and restores it. Any DB properties added since
+     * the object was serialized are backfilled with their default values.
      *
-     * @param string $serializedObject
+     * @param array $data
      */
-    public function __unserialize($serializedObject)
+    public function __unserialize(array $data): void
     {
-        $objectVars = unserialize($serializedObject);
-
-        foreach ($objectVars as $key => $value) {
+        foreach ($data as $key => $value) {
             $this->{$key} = $value;
         }
 

--- a/tests/AbstractDbEntityTest.php
+++ b/tests/AbstractDbEntityTest.php
@@ -486,6 +486,14 @@ class AbstractDbEntityTest extends \PHPUnit_Framework_TestCase
         $this->assertNotContains('private info', serialize($entity));
     }
 
+    public function testSerializeReturnsArray()
+    {
+        $entity = new TestDbEntity();
+        // PHP's __serialize() magic method must return an array; returning a string throws a
+        // TypeError on PHP >= 7.4 the moment the entity is serialized (e.g. written to a session).
+        $this->assertTrue(is_array($entity->__serialize()));
+    }
+
     public function testUnserialize()
     {
         $entity = new TestDbEntity();


### PR DESCRIPTION
## Fix: `AbstractDbEntity::__serialize()` must return an array

### Problem
`__serialize()` returns a **string** (`serialize(get_object_vars($this))`), but PHP's `__serialize()` magic method (7.4+) **must return an array**. On PHP ≥ 7.4 this throws `TypeError: __serialize() must return an array` the moment an entity is serialized — e.g. when a DB entity (like a logged-in user) is written to the session.

### Root cause / why it went unnoticed
- Introduced in **0.16.0** (commit `7a0e034`, *"Add PHP 8.2 support"*): the deprecated `Serializable` interface was dropped and `serialize()`/`unserialize()` were **mechanically renamed** to `__serialize()`/`__unserialize()` **without adapting the contract**. The stale docblocks (`Implementation of Serializable interface`, `@return string`, `@param string`) are the giveaway.
- It stayed latent because no consumer ran 0.16/0.17 on PHP 7.4+ until recently. It first surfaced in production when a consumer bumped to `0.17.0` on PHP 8.0.
- CI never caught it: `.travis.yml` only tests **PHP 7.1–7.3**, where `__serialize`/`__unserialize` are inert regular methods (magic behaviour begins at 7.4). The existing round-trip tests therefore passed, even though `composer.json` requires `php >=7.4`.

### Change
- `__serialize(): array` now returns `get_object_vars($this)` directly (no inner `serialize()`).
- `__unserialize(array $data): void` now consumes the array directly (no inner `unserialize()`); the added-column backfill logic is preserved.
- Docblocks corrected (`@return array` / typed `array $data`, drop "Serializable interface").
- Added `testSerializeReturnsArray` regression test.

### Verification (PHP 8.4)
- **Before:** `__serialize()` returns `string` → `serialize($entity)` throws `TypeError: __serialize() must return an array`.
- **After:** returns an array; `unserialize(serialize($entity))` round-trips and preserves data; private subclass properties still don't leak.